### PR TITLE
ci: stop dependabot failing on a label that does not exist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,9 @@
 ---
+# Note: no `labels:` key here on purpose. Naming labels explicitly makes
+# Dependabot require that they already exist, and it refuses to open the pull
+# request otherwise ("The following labels could not be found: dependencies").
+# Left unset, Dependabot applies its default `dependencies` label and creates
+# it if the repository does not have it yet - which is what we wanted anyway.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -7,7 +12,6 @@ updates:
       interval: monthly
     commit-message:
       prefix: "ci"
-    labels: [dependencies]
 
   - package-ecosystem: pip
     directory: /
@@ -15,4 +19,3 @@ updates:
       interval: monthly
     commit-message:
       prefix: "deps"
-    labels: [dependencies]


### PR DESCRIPTION
Naming labels explicitly in dependabot.yml makes Dependabot require that they already exist in the repository; it does not create them, and refuses to open the pull request instead:

  The following labels could not be found: `dependencies`.
  Please create it before Dependabot can add it to a pull request.

That has been firing on every Dependabot run since the config landed.

Dropping the key restores the default behaviour, which applies a `dependencies` label and creates it when the repository lacks one - the label we wanted in the first place. Creating the label by hand would work too, but would leave the config depending on repository state nothing in the repository guarantees.